### PR TITLE
@vignette edits

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,10 @@
 Package: macrosheds
-Title: Tools for interfacing with the macrosheds dataset
+Title: Tools for interfacing with the MacroSheds dataset
 Version: 0.0.0.1
 Date: 2021-11-1
-Authors@R: c(person("Spencer", "Rhea", email = "spencerrhea41@gmail.com", role = c("aut", "cre")), person("Mike", "Vlah", email = "vlahm13@gmail.com", role = c("aut")), person("Wes", "Slaughter", email = "weston.slaughter@duke.edu"))
+Authors@R: c(person("Spencer", "Rhea", email = "spencerrhea41@gmail.com", role = c("aut", "cre")),
+             person("Mike", "Vlah", email = "vlahm13@gmail.com", role = c("aut")),
+             person("Wes", "Slaughter", email = "weston.slaughter@duke.edu", role = c("aut")))
 Description: Macrosheds is a database of watershed ecosystems studies from around the world. 
 Depends: R (>= 3.6.1), tidyverse
 Imports:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,7 +8,7 @@ Authors@R: c(person("Spencer", "Rhea", email = "spencerrhea41@gmail.com", role =
 Description: Macrosheds is a database of watershed ecosystems studies from around the world. 
 Depends: R (>= 3.6.1), tidyverse
 Imports:
-    tidyverse, feather, errors, sf, data.table, EGRET, foreach, glue, parallel, dataRetrieval
+    tidyverse, feather, errors, sf, data.table, EGRET, foreach, glue, parallel, dataRetrieval, terra, mapview, elevatR, whitebox
 Roxygen: list(markdown = TRUE)
 License: MIT
 Encoding: UTF-8

--- a/R/ms_calc_flux.R
+++ b/R/ms_calc_flux.R
@@ -1,6 +1,6 @@
 #' Calculates chemical fluxes
 #' 
-#' Calculates stream discharge and precipitation fluxes of chemicals from Q (discharge 
+#' Calculates solute fluxes from Q (discharge 
 #' or precipitation) and chemistry data.
 #'
 #' @author Spencer Rhea, spencerrhea41@@gmail.com

--- a/R/ms_calc_flux.R
+++ b/R/ms_calc_flux.R
@@ -18,8 +18,8 @@
 #' Chemical flux is calculated by multiplying chemical concentration by flow
 #' of water (flux = concentration * flow). The output units depend on \code{data.type} and the time 
 #' interval at which input data are collected. If \code{q_type} is 'discharge', output units are kg/T, where T
-#' is the sample interval. Consider: kg/T = mg/L \* L/s \* T / 1e6.
-#' If \code{q_type} is 'precipitation', output is in kg/ha/T (kg/ha/T = mg/L \* mm/T / 100).
+#' is the sample interval. Consider: kg/T = mg/L * L/s * T / 1e6.
+#' If \code{q_type} is 'precipitation', output is in kg/ha/T (kg/ha/T = mg/L * mm/T / 100).
 #' You can convert between kg/ha/T and kg/T using [ms_scale_flux_by_area()] and
 #' [ms_undo_scale_flux_by_area()].
 #' 

--- a/R/ms_conversions.R
+++ b/R/ms_conversions.R
@@ -84,9 +84,8 @@ ms_conversions <- function(d,
                            convert_units_to,
                            convert_molecules){
     
-    # TEMPORARY (will replace when vars is on figshare)
-    ms_vars <<- suppressMessages(read_csv('variables.csv'))
-    
+    ms_vars <- read_csv('https://figshare.com/articles/dataset/site_metadata/19358582/files/34382849',
+                    col_types = cols())
     
     #checks
     cm <- ! missing(convert_molecules)
@@ -106,6 +105,13 @@ ms_conversions <- function(d,
         not_a_ms_var <- unique(vars[!vars %in% ms_vars$variable_code])
         stop(paste0(paste(not_a_ms_var, collapse = ', '),
                     ' is not a MacroSheds variable. only MacroSheds variables can be converted'))
+    }
+
+    if(any(duplicated(names(convert_units_from)))){
+        stop('duplicated names in convert_units_from')
+    }
+    if(any(duplicated(names(convert_units_to)))){
+        stop('duplicated names in convert_units_to')
     }
     
     vars_convertable <- ms_vars %>%
@@ -128,6 +134,9 @@ ms_conversions <- function(d,
                 stop('names of convert_units_from and convert_units_to must match')
             }
     }
+
+    convert_units_from <- tolower(convert_units_from)
+    convert_units_to <- tolower(convert_units_to)
     
     whole_molecule <- c('NO3', 'SO4', 'PO4', 'SiO2', 'SiO3', 'NH4', 'NH3',
                         'NO3_NO2')

--- a/R/ms_internals.R
+++ b/R/ms_internals.R
@@ -213,7 +213,7 @@ convert_unit <- function(x, input_unit, output_unit){
         new_bottom <- as.vector(str_split_fixed(new_fraction[2], "", n = Inf))
     }
     
-    old_top_unit <- str_split_fixed(old_top, "", 2)[1]
+    old_top_unit <- tolower(str_split_fixed(old_top, "", 2)[1])
     
     if(old_top_unit %in% c('g', 'e', 'q', 'l') || old_fraction[1] == 'mol') {
         old_top_conver <- 1
@@ -221,7 +221,7 @@ convert_unit <- function(x, input_unit, output_unit){
         old_top_conver <- as.numeric(filter(units, prefix == old_top_unit)[,2])
     }
     
-    old_bottom_unit <- str_split_fixed(old_bottom, "", 2)[1]
+    old_bottom_unit <- tolower(str_split_fixed(old_bottom, "", 2)[1])
     
     if(old_bottom_unit %in% c('g', 'e', 'q', 'l') || old_fraction[2] == 'mol') {
         old_bottom_conver <- 1
@@ -229,7 +229,7 @@ convert_unit <- function(x, input_unit, output_unit){
         old_bottom_conver <- as.numeric(filter(units, prefix == old_bottom_unit)[,2])
     }
     
-    new_top_unit <- str_split_fixed(new_top, "", 2)[1]
+    new_top_unit <- tolower(str_split_fixed(new_top, "", 2)[1])
     
     if(new_top_unit %in% c('g', 'e', 'q', 'l') || new_fraction[1] == 'mol') {
         new_top_conver <- 1
@@ -237,7 +237,7 @@ convert_unit <- function(x, input_unit, output_unit){
         new_top_conver <- as.numeric(filter(units, prefix == new_top_unit)[,2])
     }
     
-    new_bottom_unit <- str_split_fixed(new_bottom, "", 2)[1]
+    new_bottom_unit <- tolower(str_split_fixed(new_bottom, "", 2)[1])
     
     if(new_bottom_unit %in% c('g', 'e', 'q', 'l') || new_fraction[2] == 'mol') {
         new_bottom_conver <- 1

--- a/man/ms_calc_flux.Rd
+++ b/man/ms_calc_flux.Rd
@@ -22,7 +22,7 @@ returns a \code{tibble} of stream or precipitation chemical flux for every times
 where discharge/precipitation and chemistry are reported. Output units are kg/ha/timestep.
 }
 \description{
-Calculates stream discharge and precipitation fluxes of chemicals from Q (discharge
+Calculates solute fluxes from Q (discharge
 or precipitation) and chemistry data.
 }
 \details{

--- a/man/ms_conversions.Rd
+++ b/man/ms_conversions.Rd
@@ -37,7 +37,7 @@ returns a \code{tibble} in MacroSheds format, containing concentration data conv
 }
 \description{
 MacroSheds concentration data are represented in either mass, moles, or equivalents
-per liter (mg/L, mol/L, or Eq/L, respectively). Use this function to convert among
+per liter (mg/L, mol/L, or uEq/L, respectively, but note that one variable, "ANC" is represented by default in Eq/L). Use this function to convert among
 these units. You may also use this function to convert SI prefixes, e.g. mg/L to kg/L,
 or to convert between molecular and atomic representations for some elements and compounds.
 For example, nitrate (NO3) can be converted to nitrate-N and vice versa.

--- a/vignettes/ms_retrieval_flux_calc.Rmd
+++ b/vignettes/ms_retrieval_flux_calc.Rmd
@@ -1,34 +1,34 @@
 ---
-title: MacroSheds Discharge and Chemistry Data Retrieval, Preparation, and Flux Calculation 
+title: MacroSheds Discharge and Chemistry Data Retrieval and Flux Calculation 
 author: Weston Slaughter, Spencer Rhea, Mike Vlah
-subtitle: using the MacroSheds package to retrieve discharge and chemistry data for target sites and variables, as well as preparing data for and performing flux calculation 
+subtitle: Using the `macrosheds` package to retrieve discharge and chemistry data for target sites and variables, and to use it to calculate stream solute flux
 output:
-  html_document:
-    toc: true 
-    theme: united
-    highlight: zenburn
-    df_print: kable
+    html_document:
+      toc: true 
+      theme: united
+      highlight: zenburn
+      df_print: kable
 ---
 
 
 
-this walkthrough is from the persepctive of a first time user, with some knowledge of the R programming language. This example user, for a college project, needs to compare the flux of nitrate between two watersheds, one from the Eastern US and one from the Western US, each with at least 60 years of data.
+This walkthrough is from the perspective of a first time user, with some knowledge of the R programming language. This example user, for a college project, needs to compare the flux of nitrate between two watersheds, one from the Eastern US and one from the Western US, each with at least 60 years of data.
 
 
-# install and explore the MacroSheds package
+# Install and explore the `macrosheds` package
 
 
-to use the MacroSheds package, you must first **make sure you have the MacroSheds package on your computer, built, and installed in R**. Currently, the package is only available via github. If you have no already, you can install the MacroSheds package as folows: 
+To use the `macrosheds` package, you must first **make sure you have the `macrosheds` package on your computer, built, and installed in R**. Currently, the package is only available via github. If you have not already, you can install the `macrosheds` package as follows: 
 
 ```{r ms-install, eval = FALSE}
-library(devtools)
+# install.packages('devtools') #you may need to install devtools too
 
 devtools::install_github("https://github.com/MacroSHEDS/macrosheds")
 ```
 
-now, that we have the MacroSheds package,  we load it into our library, along with other packages we will be using in this walkthrough. 
+Now, that we have the `macrosheds` package,  we load it into our library, along with other packages we will be using in this walkthrough. 
 
-```{r setup-library}
+```{r setup-library, message = FALSE}
    
 library(macrosheds)
 library(dplyr)
@@ -36,19 +36,19 @@ library(ggplot2)
 
 ```
 
-In this walkthrough, to learn more about the MacroSheds package, its functions, and how to use them, we will be using the MacroSheds package's documentation. 
+In this walkthrough, to learn more about the `macrosheds` package, its functions, and how to use them, we will be using the `macrosheds` package's documentation. 
 
-Before anything else, we need to know what functions we have available. Let's explore the package with `help()`
+Before anything else, we need to know what functions are available. Let's explore the package with `help()`
 
 ```{r ms-help}
 help(package = macrosheds)
 ```
 
 
-# identify target sites and variables in the MacroSheds dataset
+# Identify target sites and variables in the MacroSheds dataset
 
 
-Our first goal is to **identify sites we might want to pull preliminary data from**. To get more information about MacroSheds' sites, we will use the function `download_ms_site_data`, which loads a tibble of MacroSheds site metadata. 
+Our first goal is to **identify sites we might want to pull data from**. To get more information about MacroSheds sites, we will use the function `download_ms_site_data`, which loads a tibble of MacroSheds site metadata. 
 
 We will use `?` to get more information about the function, and how to use it.
 
@@ -60,55 +60,54 @@ We will use `?` to get more information about the function, and how to use it.
 ?ms_download_site_data
 ```
 
-looks like the function will run with no arugments, let's run it and look at the results.
+Looks like the function will run with no arugments, let's run it and look at the results.
 
 ```{r ms-sites}
 ms_sites <- ms_download_site_data()
 colnames(ms_sites)
 ```
 
-Our objective is to find 2 watersheds, one in the Eastern US and one in the Western US, which both have at least 20 years of nitrate data.
+Our objective is to find 2 watersheds, one in the Eastern US and one in the Western US, which both have at least 60 years of nitrate data.
 
-Our `ms_sites` dataframe columns include "latitude", "longitude", "first\_record_\utc", and "last\_record\_utc". Let's use these to see what sites meet our needs.
+The `ms_sites` dataframe columns include "latitude", "longitude", "first\_record\_utc", and "last\_record\_utc". Let's use these to see what sites meet our needs.
 
 
 ```{r ms-site-filter}
 sixty_yrs_days <- 365 * 60
 
 target_sites <- ms_sites %>%
-  # eastern US < 90*W , western US > 110*W 
-  # to make sure our sites are roughly western or eastern 
-  filter(longitude > -95 | longitude < -115) %>%
-  mutate(period = as.numeric(
-           difftime(last_record_utc,
-                    first_record_utc,
-                    units = "days"
-         ))) %>%
-  filter(period > sixty_yrs_days)
-  
-  
+    # to make sure our sites are roughly western or eastern 
+    filter(longitude > -95 | longitude < -115) %>%
+    mutate(period = as.numeric(
+        difftime(last_record_utc,
+                 first_record_utc,
+                 units = "days"
+    ))) %>%
+    filter(period > sixty_yrs_days)
+    
+    
 unique(target_sites$domain)
 head(target_sites)
-
+  
 target_summary <- target_sites %>%
-  group_by(domain) %>%
-  summarise(
-    mean_long = mean(longitude),
-    sum_obs = sum(n_observations),
-    min_date = min(first_record_utc),
-    max_date = min(last_record_utc)
-  )
-
+    group_by(domain) %>%
+    summarize(
+        mean_long = mean(longitude),
+        sum_obs = sum(n_observations),
+        min_date = min(first_record_utc),
+        max_date = min(last_record_utc)
+    )
+  
 head(target_summary)
 ```
 
-From our filter of the site metadata, we have found three domains which have site data that meets our requirements. By summarising the data, we've found that two of these sites are on the east coast (Fernow, HBEF) and one is on the West Coast (HJ Andrews). Our objective is to compare two sites, one east and one west, and between Fernow and HBEF our summary data shows that HBEF has a greater number of overall observations, so we will choose HBEF. 
+From our filter of the site metadata, we have found three domains which have site data that meets our requirements. By summarizing the data, we've found that two of these sites are in the Northeastern US (Fernow, HBEF) and one is on the West Coast (HJ Andrews). Our objective is to compare two sites, one east and one west, and between Fernow and HBEF our summary data show that HBEF has a greater number of overall observations, so let's go with that. 
 
 
 #### ms\_download\_variables
 
 
-To get data for our target variable, Nitrate, let's make sure it's in the MacroSheds variable catalog, and see exactly what it is called. For this, we will use `ms_download_variables`, which also does not need arguments. 
+To get data for our target variable, nitrate, let's make sure it's in the MacroSheds variable catalog, and see exactly what it is called. For this, we will use `ms_download_variables`, which also does not need arguments. 
 
 ```{r ms-vars}
 ms_vars <- ms_download_variables()
@@ -116,26 +115,26 @@ head(ms_vars)
 ```
 
 
-This is a pretty long list, let's do a siple text search to see what variables start with "Nitr"
+This is a pretty long list, let's do a simple text search to see what variables start with "nitr"
 
 ```{r ms-vars-filter}
-ms_vars[grep("^Nitr", ms_vars$variable_name),]
+ms_vars[grep("^nitr", ms_vars$variable_name, ignore.case = TRUE),]
 ```
 
-There's a ton of results here, but I can see Nitrate, and it's variable code 'NO3'. 
+There's a ton of results here, but I can see nitrate, and its variable code: 'NO3'. 
 
 
-# retrieve discharge data for target sites
+# Retrieve discharge data for target sites
 
 
-Now, we will retrieve our target data: discharge and nitrate for our two sites. First, we make a directory to save the data to, and save a vector of our target domain names. 
+Now, we will retrieve the target data: discharge and nitrate for our two sites. First, we choose a directory to save the data to, and create a vector of target domain names. 
 
 ``` {r ms-dir}
 my_ms_dir <- "./data"
 my_domains <- c("hbef", "hjandrews")
 ```
 
-We will also take a look at ```ms_download_core_data``` which we will sue to retrieve all the available data for our domains of interest.
+We will also take a look at `ms_download_core_data` which we will use to retrieve all the available data for the target domains.
 
 
 ##### ms\_download\_core\_data
@@ -148,10 +147,12 @@ We will also take a look at ```ms_download_core_data``` which we will sue to ret
 Now, we retrieve MacroSheds data by domain and save it to our directory.
 
 ``` {r ms-data, eval = FALSE}
+options(timeout = 600) #default 60 might not be enough if your connection is slow
+
 ms_download_core_data(
-  my_ms_dir,
-  domains = my_domains,
-  quiet = FALSE
+    my_ms_dir,
+    domains = my_domains,
+    quiet = FALSE
 )
 ```
 
@@ -159,7 +160,7 @@ ms_download_core_data(
 ##### ms\_load\_product    *discharge*
 
 
-Now we have our data downloaded, but we want to load exactly the variables we need from into our R session. To do this, we use `ms_load_product`. 
+Now we have the data downloaded, but we want to load specific variables into the R session. To do this, we use `ms_load_product`. 
 
 ```{r ms-load}
 ?ms_load_product
@@ -169,51 +170,51 @@ Pointing to the directory we downloaded the data to, we use this function to pul
 
 ```{r ms-q}
 my_q <- ms_load_product(
-  my_ms_dir,
-  "discharge",
-  site_codes = c("w1", "GSWS09"),
-  sort_result = TRUE,
-  warn = TRUE
+    my_ms_dir,
+    prodname = "discharge",
+    site_codes = c("w1", "GSWS09"),
+    sort_result = TRUE,
+    warn = TRUE
 )
 ```
 
 
 
-# retrieve stream chemistry data for target sites
+# Retrieve stream chemistry data for target sites
 
 
 #### ms\_load\_product    *chemistry*
-Now that we have discharge, we will use `ms_load_product` again, but for Nitrate data.
+Now that we have discharge, we will use `ms_load_product` again, but for nitrate data.
 
 ```{r ms-chem-error, error = TRUE}
 my_chem <- ms_load_product(
-  my_ms_dir,
-  "stream_chemistry",
-  filter_vars = "NO3",
-  site_codes = c("w1", "GSWS09"),
-  sort_result = TRUE,
-  warn = TRUE
+    my_ms_dir,
+    prodname = "stream_chemistry",
+    filter_vars = "NO3",
+    site_codes = c("w1", "GSWS09"),
+    sort_result = TRUE,
+    warn = TRUE
 )
 ```
 
-As of 4/11/2022 this function returns the error message ```None of filter_vars present in this dataset```, meaning that Nitrate's variable code ```NO3``` did not match with any of the data for these sites. 
+As of 4/11/2022 this function returns the error message `None of filter_vars present in this dataset`, meaning that nitrate's variable code `NO3` did not match with any of the data for these sites. 
 
-All is not lost, it is common for sites to report, instead of NO3 concntration, ```NO3_N``` which is a measure of just the Nitrogen component of Nitrate. We can also see that NO3_N is listed in the variable search we did for variable names that start with "Nitr" earlier. Let's try again for this one. 
+All is not lost, it is common for sites to report, instead of NO3 concntration, `NO3_N` which is a measure of just the Nitrogen component of nitrate. We can also see that NO3_N is listed in the variable search we did for variable names that start with "Nitr" earlier. Let's try again for this one. 
 
 ```{r ms-chem}
 my_chem <- ms_load_product(
-  my_ms_dir,
-  "stream_chemistry",
-  filter_vars = "NO3_N",
-  site_codes = c("w1", "GSWS09"),
-  sort_result = TRUE,
-  warn = TRUE
+    my_ms_dir,
+    prodname = "stream_chemistry",
+    filter_vars = "NO3_N",
+    site_codes = c("w1", "GSWS09"),
+    sort_result = TRUE,
+    warn = TRUE
 )
 
 head(my_chem)
 ```
 
-# manipulate and clean data
+# Manipulate and clean data
 
 
 #### ms\_synchronize\_timestep
@@ -221,38 +222,40 @@ head(my_chem)
 
 Now, we have to correct for sample number differences
 
-```{r ms-sync}
+```{r ms-sync, message = FALSE}
 ?ms_synchronize_timestep
 
 my_chem_sync <- ms_synchronize_timestep(
-                  my_chem,
-                  "1 day",
-                  40
-                )
+    my_chem,
+    desired_interval = "1 day",
+    impute_limit = 40
+)
 ```
 
-# calculate flux from this data
+# Calculate flux from this data
 
 
 #### ms\_calc\_flux
 
 
-Success! Now, let's use ```ms_calc_flux``` to use our discharge and chemistry data to calculate Nitrate-Nitrogen flux for our target sites. 
+Success! Now, let's use `ms_calc_flux` to calculate nitrate-nitrogen flux from discharge and concentration. 
 
 ```{r}
 ?ms_calc_flux
 ```
 
-we can plug in our discharge and chemistry data directly. 
+We can plug in our discharge and chemistry data directly. 
 
 ```{r ms-flux}
-my_flux <- ms_calc_flux(chemistry = my_chem_sync,
-                      q = my_q,
-                      q_type = 'discharge')
+my_flux <- ms_calc_flux(
+    chemistry = my_chem_sync,
+    q = my_q,
+    q_type = 'discharge'
+)
 head(my_flux)
 ```
 
-from the documentation of ```ms_calc_flux``` we know that, based on our input flow type ('discharge' as opposed to 'precipitation'), that our flux units are ```kg/T``` where T is the sampling interval. However, we are comparing between two very different watersheds- and it would be appropriate to scale by area. MacroSheds provides```ms_scale_flux_by_area``` for this very purpose.
+From the documentation of `ms_calc_flux` we know, based on our input flow type ('discharge' as opposed to 'precipitation'), that our flux units are `kg/T` where T is the sampling interval. However, we are comparing between two very different watersheds- and it would be appropriate to scale by area. MacroSheds provides`ms_scale_flux_by_area` for this very purpose.
 
 
 #### ms\_scale\_flux\_by\_area
@@ -262,21 +265,22 @@ from the documentation of ```ms_calc_flux``` we know that, based on our input fl
 my_flux_scaled <- ms_scale_flux_by_area(my_flux)
 ```
 
-looks great -- let's plot it!
+Looks great -- let's plot it!
 
 ```{r ms-explore}
 my_annual_mean_flux <- my_flux_scaled %>%
-  mutate(year = as.numeric(format(as.Date(datetime), format="%Y"))) %>%
-  group_by(year, site_code) %>%
-  summarise(
-    mean_flux = sum(val),
-    n = n()
-  ) %>%
-  filter(n > 330)
+    mutate(year = as.numeric(format(as.Date(datetime), format="%Y"))) %>%
+    group_by(year, site_code) %>%
+    summarize(
+        mean_flux = sum(val),
+        n = n(),
+        .groups = 'drop',
+    ) %>%
+    filter(n > 330)
 
 ggplot(data=my_annual_mean_flux, aes(x=year, y=mean_flux, group=site_code)) +
-  geom_line(aes(color=site_code))+
-  geom_point() +
-  ggtitle("Nitrate Flux (kg/ha/day)") +
-  theme_minimal()
+    geom_line(aes(color=site_code))+
+    geom_point() +
+    ggtitle("Nitrate-N Flux (kg/ha/day)") +
+    theme_minimal()
 ```


### PR DESCRIPTION
@westonslaughter 
I love this. super clean and clear. It would be awesome if we could add this and future vignettes to the package officially, so they can be queried with `vignette(package = 'macrosheds')` and opened with `vignette('topic', package = 'macrosheds')`. And then they could all be stitched together in bookdown and hosted on the portal as a turbo-compendium!

My edits might get lost in the tab-width changes, so i've summarized them here:
  + sometimes your tab widths are set to 4, and other times 2. maybe on different machines/editors? 4 is the way!
  + for inline code-style text, use \`code\`. the triple-backtick is for multiline code blocks
  + NO3, SO4, etc are rare in MacroSheds, because we convert them to NO3-N, SO4-S, etc. This is true for NO3 SO4 PO4 SiO2 SiO3 NH4 NH3 and NO3+NO2. I usually say something like, "concentrations of these molecules are expressed in terms of the mass of their primary constituent atom, for consistency." Only if a primary source reports e.g. both NO3 and NO3_N concentration do we then report both. So in the vignette, let's ask for NO3_N and drop the part where we request NO3 and get an error message.
  + whenever you call `group_by`, it's good practice to ungroup. You can do that either by calling `ungroup()`, or by using `.groups = 'drop'` within your call to `summarize`, `mutate`, etc.
  + `summarize` is an alias for `summarise`, kindly provided for us U.S. folk

  + heading capitalization