### PR TITLE
figshare data download test, and readout, on library(macrosheds) call

### DIFF
--- a/R/ms_download_ws_attr.R
+++ b/R/ms_download_ws_attr.R
@@ -16,7 +16,7 @@
 #'    files is loaded with [ms_load_ws_attr()].
 #' @param quiet logical. If TRUE, some messages will be suppressed.
 #' @param omit_climate_data logical. Ignored if \code{dataset == 'summaries'}. However, if
-#'    \code{dataset == 'time series'), and you don't care about climate data,
+#'    \code{dataset == 'time series'}), and you don't care about climate data,
 #'    you may use this argument to avoid downloading it (because it's huge), while still downloading
 #'    terrain, vegetation, parent material, land use, and hydrology data (which are tiny).
 #' @return returns NULL. Writes files to disk.

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,59 +1,56 @@
-## .onAttach <- function(libname, pkgname) {
-##   # load in macrosheds 'sysdata' from gihtub location
-##   ms_sysdata_url <- "https://github.com/MacroSHEDS/macrosheds/raw/master/data/sysdata2.RData"
-##   temp_dir <- tempdir()
-##   temp_file_dom <- file.path(temp_dir, 'sysdata.Rdata')
-
-##   download_status <- try(download.file(url = ms_sysdata_url,
-##                                        destfile = temp_file_dom))
-
-##   if(inherits(download_status, 'try-error')) {
-##     warning('unable to download macrosheds sysdata for macrosheds data version',
-##             '(cannot gaurantee user local macrosheds download functions will work)')
-##   } else {
-##     file_ids <- loadRData(temp_file_dom, verbose = TRUE)
-##     ms_sysdata_github <- file_ids_for_r_package2
-##     ms_sysdata_local <-
-
-##   }
-
-
-
-
-##   packageStartupMessage("This is version ", packageVersion(pkgname),
-##                         " of ", pkgname, "\n",
-##                         "This package is licensed under MIT, but licensing of MacroSheds data is more complex. See ",
-##                         "https://docs.google.com/document/d/1CPaQ705QyoWfu6WjA4xHgQooCQ8arq3NZ8DO9tb9jZ0/edit?usp=sharing")
-## }
-
-## url("https://figshare.com/articles/dataset/watershed_summaries/16653064")
-
 .onAttach <- function(libname, pkgname) {
-  packageStartupMessage("This is version ", packageVersion(pkgname), " of ", pkgname, "\n",
-                        "This package is licensed under MIT, but licensing of MacroSheds data is more complex. See ",
-                        "https://docs.google.com/document/d/1CPaQ705QyoWfu6WjA4xHgQooCQ8arq3NZ8DO9tb9jZ0/edit?usp=sharing")
+  # check if user has internet connection
+  site <- "http://example.com/"
+  is_online <- tryCatch(
+    expr = {
+      readLines(site, n=1)
+      TRUE
+    },
+    # add handling for slow connection speed?
+    warning = function(w) invokeRestart("muffleWarning"),
+    error = function(e) FALSE
+  )
 
-  temp_dir <- tempdir()
-  temp_file_dom <- paste0(temp_dir, 'test.feather')
+  # if connected, check if user's local macrosheds figshare IDs
+  # result in successful download
+  if(is_online) {
+      temp_dir <- tempdir()
+      temp_file_dom <- paste0(temp_dir, 'test.feather')
 
-  figshare_base <- 'https://figshare.com/ndownloader/files/'
-  figshare_codes <- macrosheds::file_ids_for_r_package2 #loaded in R/sysdata2.rda
+      figshare_base <- 'https://figshare.com/ndownloader/files/'
+      figshare_codes <- macrosheds::file_ids_for_r_package2 #loaded in R/sysdata2.rda
 
-  test_info <- figshare_codes[which(figshare_codes$ut == 'watershed_summaries'),]
-  test_url <- paste0(figshare_base, test_info[2])
+      test_info <- figshare_codes[which(figshare_codes$ut == 'watershed_summaries'),]
+      test_url <- paste0(figshare_base, test_info[2])
 
-  download_status <- try(download.file(url = test_url,
-                                       destfile = temp_file_dom,
-                                       quiet = TRUE,
-                                       cacheOK = FALSE,
-                                       mode = 'wb'))
+      download_status <- try(download.file(url = test_url,
+                                           destfile = temp_file_dom,
+                                           quiet = TRUE,
+                                           cacheOK = FALSE,
+                                           mode = 'wb'))
+
+      data_status <- try(feather::read_feather(temp_file_dom))
 
 
-  if(inherits(download_status, 'try-error')) {
-    return('unable to download macrosheds data from figshare, local figshare IDs do not match latest dataset version.',
-            'cannot gaurantee user local macrosheds download functions will work, please re-install macrosheds from github',
-            'to ensure full functionality.')
+      # if download error
+      if(inherits(data_status, 'try-error')) {
+          figshare_message <- paste0('-- MacroSheds dataset version check -- FAIL unable to download macrosheds data from figshare, local figshare IDs do not match latest dataset version.',
+                'cannot gaurantee user local macrosheds download functions will work, please re-install macrosheds from github',
+                'to ensure full functionality.')
+      } else {
+      # if download success, assumed figshare IDs are accurate
+          figshare_message <- '-- MacroSheds dataset version check -- SUCCESS dataset download connection tested and local macrosheds version has up-to-date IDs'
+      }
   } else {
-    return(invisible())
+    figshare_message <- '-- MacroSheds dataset version check -- UNKNOWN no internet connection detetcted, dataset download connection untested'
   }
+
+  # message
+  packageStartupMessage(
+    "\n\nThis is version ", packageVersion(pkgname), " of the ", pkgname, "R package \n\n",
+    "This package is licensed under MIT, but licensing of MacroSheds data is more complex. See \n",
+    "https://docs.google.com/document/d/1CPaQ705QyoWfu6WjA4xHgQooCQ8arq3NZ8DO9tb9jZ0/edit?usp=sharing",
+    "\n\n",
+    figshare_message
+  )
 }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,6 +1,59 @@
+## .onAttach <- function(libname, pkgname) {
+##   # load in macrosheds 'sysdata' from gihtub location
+##   ms_sysdata_url <- "https://github.com/MacroSHEDS/macrosheds/raw/master/data/sysdata2.RData"
+##   temp_dir <- tempdir()
+##   temp_file_dom <- file.path(temp_dir, 'sysdata.Rdata')
+
+##   download_status <- try(download.file(url = ms_sysdata_url,
+##                                        destfile = temp_file_dom))
+
+##   if(inherits(download_status, 'try-error')) {
+##     warning('unable to download macrosheds sysdata for macrosheds data version',
+##             '(cannot gaurantee user local macrosheds download functions will work)')
+##   } else {
+##     file_ids <- loadRData(temp_file_dom, verbose = TRUE)
+##     ms_sysdata_github <- file_ids_for_r_package2
+##     ms_sysdata_local <-
+
+##   }
+
+
+
+
+##   packageStartupMessage("This is version ", packageVersion(pkgname),
+##                         " of ", pkgname, "\n",
+##                         "This package is licensed under MIT, but licensing of MacroSheds data is more complex. See ",
+##                         "https://docs.google.com/document/d/1CPaQ705QyoWfu6WjA4xHgQooCQ8arq3NZ8DO9tb9jZ0/edit?usp=sharing")
+## }
+
+## url("https://figshare.com/articles/dataset/watershed_summaries/16653064")
+
 .onAttach <- function(libname, pkgname) {
-  packageStartupMessage("This is version ", packageVersion(pkgname),
-                        " of ", pkgname, "\n",
+  packageStartupMessage("This is version ", packageVersion(pkgname), " of ", pkgname, "\n",
                         "This package is licensed under MIT, but licensing of MacroSheds data is more complex. See ",
                         "https://docs.google.com/document/d/1CPaQ705QyoWfu6WjA4xHgQooCQ8arq3NZ8DO9tb9jZ0/edit?usp=sharing")
+
+  temp_dir <- tempdir()
+  temp_file_dom <- paste0(temp_dir, 'test.feather')
+
+  figshare_base <- 'https://figshare.com/ndownloader/files/'
+  figshare_codes <- macrosheds::file_ids_for_r_package2 #loaded in R/sysdata2.rda
+
+  test_info <- figshare_codes[which(figshare_codes$ut == 'watershed_summaries'),]
+  test_url <- paste0(figshare_base, test_info[2])
+
+  download_status <- try(download.file(url = test_url,
+                                       destfile = temp_file_dom,
+                                       quiet = TRUE,
+                                       cacheOK = FALSE,
+                                       mode = 'wb'))
+
+
+  if(inherits(download_status, 'try-error')) {
+    return('unable to download macrosheds data from figshare, local figshare IDs do not match latest dataset version.',
+            'cannot gaurantee user local macrosheds download functions will work, please re-install macrosheds from github',
+            'to ensure full functionality.')
+  } else {
+    return(invisible())
+  }
 }


### PR DESCRIPTION
onAttach() in zzz.R now tries to download watershed summary data from figshare to a temporary directory using the local environment figshare IDs