### PR TITLE
rsfme edits related to code review

### DIFF
--- a/R/ms_calc_flux.R
+++ b/R/ms_calc_flux.R
@@ -1,7 +1,7 @@
-#' Calculates chemical fluxes
+#' Calculate daily solute fluxes
 #'
-#' Calculates solute fluxes from Q (discharge
-#' or precipitation) and chemistry data.
+#' Determines solute fluxes from interpolated daily Q (discharge
+#' or precipitation) and corresponding chemistry data.
 #'
 #' @author Spencer Rhea, spencerrhea41@@gmail.com
 #' @author Mike Vlah
@@ -16,7 +16,10 @@
 #' @return returns a \code{tibble} of stream or precipitation chemical flux for every timestep
 #'    where discharge/precipitation and chemistry are reported. Output units are kg/ha/timestep.
 #' @details
-#' Chemical flux is calculated by multiplying chemical concentration by flow
+#' 
+#' For monthly and annual fluxes computed by various methods, see [ms_calc_flux_rsfme()].
+#' 
+#' Here, solute flux is calculated by multiplying solute concentration by flow
 #' of water (flux = concentration * flow). The output units depend on the time
 #' interval at which input data are collected. The resulting flux units will always be
 #' kg/ha/T, where T is the time interval of the input \code{tibble}. \code{q_type} is used
@@ -30,7 +33,7 @@
 #' Before running [ms_calc_flux()], ensure both \code{q} and
 #' \code{chemistry} have the same time interval. See [ms_synchronize_timestep()].
 #' Also ensure chemistry units are mg/L. See [ms_conversions()].
-#' @seealso [ms_synchronize_timestep()], [ms_conversions()], [ms_scale_flux_by_area()], [ms_undo_scale_flux_by_area()]
+#' @seealso [ms_calc_flux_rsfme()], [ms_synchronize_timestep()], [ms_conversions()], [ms_scale_flux_by_area()], [ms_undo_scale_flux_by_area()]
 #' @export
 #' @examples
 #' #' ### Load some MacroSheds data:

--- a/R/ms_calc_flux_rsfme.R
+++ b/R/ms_calc_flux_rsfme.R
@@ -32,7 +32,6 @@
 #' \code{chemistry} have the same time interval. See [ms_synchronize_timestep()].
 #' Also ensure chemistry units are mg/L. See [ms_conversions()].
 #' @seealso [ms_synchronize_timestep()], [ms_conversions()], [ms_scale_flux_by_area()], [ms_undo_scale_flux_by_area()]
-#' @export
 #' @examples
 #' #' ### Load some MacroSheds data:
 #' ms_root = 'data/macrosheds'

--- a/R/ms_calc_flux_rsfme.R
+++ b/R/ms_calc_flux_rsfme.R
@@ -1,7 +1,8 @@
-#' Calculates chemical fluxes
+#' Calculate monthly or annual solute fluxes
 #'
-#' Calculates solute fluxes from Q (discharge
-#' or precipitation) and chemistry data.
+#' Determines solute fluxes from daily Q (stream discharge
+#' or precipitation depth) and corresponding chemistry data using
+#' five available methods.
 #'
 #' @author Wes Slaughter, \email{wslaughter@@berkeley.edu}
 #' @author Nick Gubbins, \email{gubbinsnick@@gmail.com}
@@ -10,8 +11,8 @@
 #'
 #' @param chemistry \code{data.frame}. A \code{data.frame} of precipitation or
 #'    stream chemistry data in MacroSheds format and in units of mg/L.
-#' @param q \code{data.frame}. A \code{data.frame} of precipitation or stream
-#'    discharge in MacroSheds format and in units of mm or L/s, respectively.
+#' @param q \code{data.frame}. A \code{data.frame} of stream
+#'    discharge (L/s) or precipitation depth (mm) in MacroSheds format.
 #' @param q_type character. Either 'precipitation' or 'discharge'.
 #' @param verbose logical. Default TRUE; prints more information to console.
 #' @return returns a \code{tibble} of stream or precipitation chemical flux for every timestep
@@ -51,7 +52,9 @@
 #'                      q_type = 'discharge',
 #'                      method = c('beale', 'pw'))
 
-ms_calc_flux_rsfme <- function(chemistry, q, q_type, verbose = TRUE, method = c('average', 'beale', 'pw', 'rating', 'composite'), aggregation = 'annual', good_year_check = TRUE) {
+ms_calc_flux_rsfme <- function(chemistry, q, q_type, verbose = TRUE,
+                               method = c('average', 'beale', 'pw', 'rating', 'composite'),
+                               aggregation = 'annual', good_year_check = TRUE) {
 
     library("dplyr", quietly = TRUE)
 
@@ -99,7 +102,8 @@ ms_calc_flux_rsfme <- function(chemistry, q, q_type, verbose = TRUE, method = c(
       stop(glue::glue('at least one flux calculation method supplied is not in accepted list, must be one of the following:\n {list}',
                 list = rsfme_accepted))
     } else {
-      writeLines(glue::glue('calculating flux using method(s): {method}', method = list(method)))
+      print(glue::glue('calculating flux using method(s): {m}',
+                       m = paste(method, collapse = ', ')))
     }
 
     riverload_methods <- c('pw', 'beale', 'rating', 'composite')
@@ -720,103 +724,3 @@ ms_calc_flux_rsfme <- function(chemistry, q, q_type, verbose = TRUE, method = c(
   # TODO: log file option
   # TODO: make handling and make clear that RSFME methods are for q_type discharge only
 }
-
-## ms_root = '../data/ms/'
-
-## chemistry <- ms_load_product(macrosheds_root = ms_root,
-##                              prodname = 'stream_chemistry',
-##                              site_codes = c('w1'),
-##                              filter_vars = c('Na'))
-
-## q <- ms_load_product(macrosheds_root = ms_root,
-##                      prodname = 'discharge',
-##                      site_codes = c('w1'))
-
-## flux_annual <- ms_calc_flux_rsfme(chemistry = chemistry,
-##                      q = q,
-##                      q_type = 'discharge',
-##                      aggregation = 'annual')
-
-## flux_monthly <- ms_calc_flux_rsfme(chemistry = chemistry,
-##                      q = q,
-##                      q_type = 'discharge',
-##                      aggregation = 'monthly')
-
-## # NOTE:  sum of period weiughted monthly is 100,000x the annual flux estimate
-print('period weighted')
-flux_annual_select <- flux_annual %>%
-  filter(site_code == 'w1',
-         method == 'pw',
-         wy == '1966')
-
-flux_monthly_select <- flux_monthly %>%
-  filter(site_code == 'w1',
-         method == 'pw',
-         wy == '1966')
-head(flux_annual_select, 20)
-head(flux_monthly_select, 20)
-sum(flux_monthly_select$val)
-mean(flux_monthly_select$val)
-
-## # NOTE: annual average is approx the mean of the monthly estimates, but well below the sum
-## print('average')
-## flux_annual_select <- flux_annual %>%
-##   filter(site_code == 'w1',
-##          method == 'average',
-##          wy == '1966')
-
-## flux_monthly_select <- flux_monthly %>%
-##   filter(site_code == 'w1',
-##          method == 'average',
-##          wy == '1966')
-## head(flux_annual_select, 20)
-## head(flux_monthly_select, 20)
-## sum(flux_monthly_select$val)
-## mean(flux_monthly_select$val)
-
-## ## # NOTE: sum pretty close
-## print('composite')
-## flux_annual_select <- flux_annual %>%
-##   filter(site_code == 'w1',
-##          method == 'composite',
-##          wy == '1966')
-
-## flux_monthly_select <- flux_monthly %>%
-##   filter(site_code == 'w1',
-##          method == 'composite',
-##          wy == '1966')
-## head(flux_annual_select, 20)
-## head(flux_monthly_select, 20)
-## sum(flux_monthly_select$val)
-## mean(flux_monthly_select$val)
-
-## ## # NOTE: sum pretty close
-## print('beale')
-## flux_annual_select <- flux_annual %>%
-##   filter(site_code == 'w1',
-##          method == 'beale',
-##          wy == '1966')
-
-## flux_monthly_select <- flux_monthly %>%
-##   filter(site_code == 'w1',
-##          method == 'beale',
-##          wy == '1966')
-## head(flux_annual_select, 20)
-## head(flux_monthly_select, 20)
-## sum(flux_monthly_select$val)
-## mean(flux_monthly_select$val)
-
-## # NOTE: sum pretty close
-## flux_annual_select <- flux_annual %>%
-##   filter(site_code == 'w1',
-##          method == 'rating',
-##          wy == '1966')
-
-## flux_monthly_select <- flux_monthly %>%
-##   filter(site_code == 'w1',
-##          method == 'rating',
-##          wy == '1966')
-## head(flux_annual_select, 20)
-## head(flux_monthly_select, 20)
-## sum(flux_monthly_select$val)
-## mean(flux_monthly_select$val)

--- a/R/ms_download_ws_attr.R
+++ b/R/ms_download_ws_attr.R
@@ -117,7 +117,6 @@ ms_download_ws_attr <- function(macrosheds_root, dataset = 'summaries', quiet = 
                   quiet = quiet,
                   cacheOK = FALSE,
                   mode = 'wb'))
-        }
     
         options(timeout = default_timeout)
 

--- a/R/ms_load_product.R
+++ b/R/ms_load_product.R
@@ -11,14 +11,14 @@
 #'    If you specified different locations with each of these functions, you'll need to
 #'    refer to them separately when loading time-series data vs. watershed attribute data.
 #' @param prodname character. A MacroSheds product name. Files associated with this
-#'    product name will be read and combined. Available prodnames are (for core time-series products):
+#'    product name will be read and combined (see * caveat). Available prodnames are (for core time-series products):
 #'
 #' + discharge
 #' + stream_chemistry
-#' + stream_flux_inst
+#' + stream_flux*
 #' + precipitation,
 #' + precip_chemistry
-#' + precip_flux_inst
+#' + precip_flux*
 #'
 #' (and for watershed attribute products):
 #'
@@ -32,8 +32,9 @@
 #' + ws_attr_CAMELS_summaries
 #' + ws_attr_CAMELS_Daymet_forcings
 #'
-#'    note that all products with flux_inst suffixes cannot be loaded using
+#'    *note that flux products cannot be loaded using
 #'    this function, but can be calculated from component products using [ms_calc_flux()]
+#'    and [ms_calc_flux_rsfme()].
 #' @param filter_vars character vector. for products like stream_chemistry that include
 #'    multiple variables, this filters to just the ones specified (ignores
 #'    variable prefixes). Ignored if requesting discharge, precipitation, or watershed attributes.
@@ -75,9 +76,9 @@ ms_load_product <- function(macrosheds_root,
     
     # Checks
     avail_prodnames <- c('discharge', 'stream_chemistry',
-                         'stream_flux_inst', 'stream_flux_inst_scaled',
+                        # 'stream_flux_inst', 'stream_flux_inst_scaled',
                          'precipitation', 'precip_chemistry',
-                         'precip_flux_inst', 'precip_flux_inst_scaled',
+                        # 'precip_flux_inst', 'precip_flux_inst_scaled',
                          'ws_attr_summaries', 'ws_attr_timeseries:climate',
                          'ws_attr_timeseries:hydrology', 'ws_attr_timeseries:landcover',
                          'ws_attr_timeseries:parentmaterial', 'ws_attr_timeseries:terrain',
@@ -97,6 +98,11 @@ ms_load_product <- function(macrosheds_root,
         stop('prodname must be a character string')
     }
     if(! prodname %in% avail_prodnames){
+
+        if(grepl(prodname, '_flux_')){
+            stop('Use ms_calc_flux_rsfme or ms_calc_flux to generate MacroSheds flux products.')
+        }
+
         stop(paste0('prodname must be one of: "',
                     paste(avail_prodnames, collapse = '", "'),
                     '".'))

--- a/man/ms_calc_flux.Rd
+++ b/man/ms_calc_flux.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/ms_calc_flux.R
 \name{ms_calc_flux}
 \alias{ms_calc_flux}
-\title{Calculates chemical fluxes}
+\title{Calculates daily chemical fluxes}
 \usage{
 ms_calc_flux(chemistry, q, q_type, verbose = TRUE, ws_area_scaled = TRUE)
 }
@@ -25,7 +25,7 @@ where discharge/precipitation and chemistry are reported. Output units are kg/ha
 }
 \description{
 Calculates solute fluxes from Q (discharge
-or precipitation) and chemistry data.
+or precipitation) and corresponding chemistry data.
 }
 \details{
 Chemical flux is calculated by multiplying chemical concentration by flow

--- a/man/ms_calc_flux_rsfme.Rd
+++ b/man/ms_calc_flux_rsfme.Rd
@@ -18,8 +18,8 @@ ms_calc_flux_rsfme(
 \item{chemistry}{\code{data.frame}. A \code{data.frame} of precipitation or
 stream chemistry data in MacroSheds format and in units of mg/L.}
 
-\item{q}{\code{data.frame}. A \code{data.frame} of precipitation or stream
-discharge in MacroSheds format and in units of mm or L/s, respectively.}
+\item{q}{\code{data.frame}. A \code{data.frame} of stream
+discharge (L/s) or precipitation depth (mm) in MacroSheds format.}
 
 \item{q_type}{character. Either 'precipitation' or 'discharge'.}
 

--- a/man/ms_download_core_data.Rd
+++ b/man/ms_download_core_data.Rd
@@ -4,7 +4,13 @@
 \alias{ms_download_core_data}
 \title{Download macrosheds core datasets}
 \usage{
-ms_download_core_data(macrosheds_root, networks, domains, quiet = FALSE)
+ms_download_core_data(
+  macrosheds_root,
+  networks,
+  domains,
+  version = "1.0",
+  quiet = FALSE
+)
 }
 \arguments{
 \item{macrosheds_root}{character. Directory where macrosheds data files will be downloaded.
@@ -17,6 +23,9 @@ for networks available for download.}
 \item{domains}{character vector. macrosheds domains that will be downloaded.
 Either a single domain, vector of domains, or 'all'. See \code{ms_downloadsite_data()}
 for domains available for download.}
+
+\item{version}{character. The MacroSheds dataset version to download, e.g. "1.0". Defaults to
+most recent. As of 2023-03-17, only version 1.0 is available, so this parameter is a stub.}
 
 \item{quiet}{logical. If TRUE, some messages will be suppressed.}
 }

--- a/man/ms_download_ws_attr.Rd
+++ b/man/ms_download_ws_attr.Rd
@@ -8,7 +8,9 @@ ms_download_ws_attr(
   macrosheds_root,
   dataset = "summaries",
   quiet = FALSE,
-  omit_climate_data = FALSE
+  version = "1.0",
+  omit_climate_data = FALSE,
+  timeout = 10000
 )
 }
 \arguments{
@@ -27,9 +29,14 @@ for a list of discrepancies. Once downloaded, data can be loaded into R with \co
 
 \item{quiet}{logical. If TRUE, some messages will be suppressed.}
 
+\item{version}{character. The MacroSheds dataset version to download, e.g. "1.0". Defaults to
+most recent. As of 2023-03-17, only version 1.0 is available, so this parameter is a stub.}
+
 \item{omit_climate_data}{logical. Ignored unless \code{dataset == 'time series'}. If you don't care about climate data,
 you may use this argument to avoid downloading it (because it's huge), while still downloading
 terrain, vegetation, parent material, land use, and hydrology data (which are tiny).}
+
+\item{timeout}{integer. Temporarily overrides getOption(timeout).}
 }
 \value{
 Returns NULL. Downloads watershed attribute data to the

--- a/man/ms_load_product.Rd
+++ b/man/ms_load_product.Rd
@@ -22,14 +22,14 @@ If you specified different locations with each of these functions, you'll need t
 refer to them separately when loading time-series data vs. watershed attribute data.}
 
 \item{prodname}{character. A MacroSheds product name. Files associated with this
-product name will be read and combined. Available prodnames are (for core time-series products):
+product name will be read and combined (see * caveat). Available prodnames are (for core time-series products):
 \itemize{
 \item discharge
 \item stream_chemistry
-\item stream_flux_inst
+\item stream_flux*
 \item precipitation,
 \item precip_chemistry
-\item precip_flux_inst
+\item precip_flux*
 }
 
 (and for watershed attribute products):
@@ -44,8 +44,9 @@ product name will be read and combined. Available prodnames are (for core time-s
 \item ws_attr_CAMELS_summaries
 \item ws_attr_CAMELS_Daymet_forcings
 
-note that all products with flux_inst suffixes cannot be loaded using
+*note that flux products cannot be loaded using
 this function, but can be calculated from component products using \code{\link[=ms_calc_flux]{ms_calc_flux()}}
+and \code{\link[=ms_calc_flux_rsfme]{ms_calc_flux_rsfme()}}.
 }}
 
 \item{filter_vars}{character vector. for products like stream_chemistry that include

--- a/tests/testthat/test_ms_calc_flux_rsfme.R
+++ b/tests/testthat/test_ms_calc_flux_rsfme.R
@@ -1,7 +1,7 @@
 library(macrosheds)
 library(testthat)
 
-## setwd('./tests/testthat/')
+# setwd('./tests/testthat/')
 ms_root = '../../data/ms_test/'
 
 chemistry <- ms_load_product(macrosheds_root = ms_root,
@@ -24,6 +24,7 @@ test_that("dataframe returned with all input sites, input years, and calculated 
 
   # calc flux
   ms_flux <- ms_calc_flux_rsfme(chemistry = chemistry, q = q, q_type = 'discharge', method = 'rsfme')
+  ms_flux <- ms_calc_flux_rsfme(chemistry = chemistry, q = q, q_type = 'discharge', method = 'average', aggregation = 'monthly')
 
   # output
   output_sites <- sort(unique(ms_flux$site_code))


### PR DESCRIPTION
@westonslaughter @ecogub 

NOTES

some line numbers may be off, as i may have moved stuff around after listing them.

check git diffs. i made lots of changes


THINGS TO DISCUSS

do we need q_type to be an input parameter? that information is def contained in the var columns of q and chemistry.
i can't remember now why Spencer and I decided that was necessary in ms_calc_flux, but it sure seems superfluous now.

are output units correct? i see a lot of dividing by (1000*area) in ms_internals.R, but shouldn't that be 1000000*area to get from mg to kg? could totally be overlooking conversions happening elsewhere.

has it been verified that ms_calc_flux_rsfme produces the same outputs as the equivalent code in ecogub/RSFME? this is a must.


CHANGES AND COMMENTARY

The documentation needs to be updated. I changed the
tagline and description, but most of this appears to be identical to ms_calc_flux.
the new parameters need definitions, and the details and examples should be updated.
explain in the description (or in the parameter definitions where appropriate) that:
    ms_interp == 1 values are automatically removed for rsfme methods
    start_month for water years is hardcoded to 10 (Oct)
    "good years" for Q are those with >= 311 days (i.e. approximately 85% coverage).
    "good years" are defined differently for chem
    if you're going to use the term "ideal method", explain that here. could use "Recommended"
    anything else that doesn't go without saying!

more tests necessary in test_ms_calc_flux_rsfme. give it a very small but "dimensionally complete" test dataset,
e.g. two sites, two variables, maybe two months worth of observations. then you can run a dozen or so tests without
bogging down the overall test sequence (though you'll also have to make it run only the selected methods, rather than
running all and then filtering). we want to test not only the garden-variety runs
(q_type = 'discharge', method = 'rsfme'), but also the more obscure parameter options, like good_year_check
and method = <subset of full option list>. the tests don't have to be full-factorial, but they should cover a lot of ground.
This function is basically the keystone of MacroSheds, so let's make sure it's rock solid.

[line 94] is "simple" an rsfme method?

with `glue`, you can either include variables as in
    x = 'b'; glue('a{x}c')
or
    glue('a{x}c', x = 'b')
so constructs like this are redundant
    x = 'b'; glue('a{x}c', x = x)

[103, 106, etc.] this construct is useful in like 30% of console messages:
    paste(some_vector, collapse = ', ')
e.g.
    print(glue('calculating flux using method(s): {m}', m = paste(method, collapse = ', ')))
instead of
    print(glue('calculating flux using method(s): {m}', m = list(method))
which leaves junk characters

[105, etc.] writeLines is generally for writing to connections. just use print() for printing to console.
but maybe this is here with the intention to set up logging at a later date, in which case gg.

[112] i love the way you check whether RiverLoad is installed! haven't used find.packge before.

[114] instead of
    if(class(x) == 'try-error')
use
    if(inherits(x, 'try-error'))
which will work even if x has multiple classes.

[127] is "simple" both a method and an aggregation option? i think this is a vestige,
but please make sure.

[line 149] the following checks whether set x is a subset of y, but not the converse
    if(all(x %in% y))
to check both at the same time, use
    if(setequal(x, y))

[158-64] i'm stoked that this is set up to handle different sample frequencies! looks like heavy tweaking necessary
though to make this fully realized, like the join_distance for approxjoin and the number of days in a good year. 
of course we don't need that now.

daterange on line 237 and chunk_daterange on 345 are determined on the chemistry dataset.
should it be determined instead on the discharge dataset,
which might extend beyond chemistry by a few weeks and still be informative? you could filter the q set so that it extends
beyond chem by at most x weeks in either direction.

[280-333] zomg, this fully replaces ms_calc_flux! that's great! let's get rid of that function and rename this one ms_calc_flux
(since even i still can't remember what rsfme stands for). that will require further updating the function documentation at
the top. also, Wes, I think you added the ws_area_scaled parameter to ms_calc_flux. probably that should be ported over,
as currently method "simple" yields unscaled flux, whereas all other methods yield area-scaled flux (right?).
Let's get rid of that acronym wherever possible, like in the error text on line 70 and even the argument to `method`.
How about "all"?

instead of [280]
    if('simple' %in% method)
and separately [688]
    if(any(method == 'simple'))
can we add some handling right at the start so that the user knows what they're getting? i.e. if they
specified method = c('simple', 'rsfme'), they're already confused. we need to indicate unequivocally that "simple" means
daily flux is returned, and all the other methods are governed by "aggregation". the clearest design would
issue an error if method = 'simple' and aggregation = 'monthly' or 'yearly'. that would mean the default for aggregation
would be NULL. likewise, if method = 'rating' and aggregation isn't specified, there would be an error stating "aggregation must
be specified when method is 'rating'". errors are good, especially for the manual-averse.
ideally, they guide users toward proper usage.

this comment seems like something you were going to come back to:
    # this is the step where concentration value errors turn to NA

in mean_or_x, you're taking the mean of the variance. probably this would cause chaos if we weren't on a daily timestep.
this function seems to be based on sd_or_0 in data_processing/src/global/global_helpers.R, but see how that function is used
elsewhere in global_helpers.R. probably that implementation could help with any NA error values youre seeing re: comment above.

[441, 448] flag_df is never used again. 

[467-473] it looks like you meant to carry on with separate dataframes, two with uncertainty and two without,
but con_target_year and q_target_year are never used again, and chem_df_errors and q_df_errors are immediately reassigned
to chem_df and q_df. RAM is not happy! there's actually a ton of reassignment going on around this area, and while
new variable names can sometimes improve clarity, here they detract from it, while spamming memory
(which wouldn't be an issue in Python, which binds variables by reference, but totally is for R with its
variable copying behavior). this will become an issue at higher sample frequencies than daily.

[486, 495] grouping by water year shouldn't be necessary here, since we're operating on raw_data_target_year

[540] probs should be an error

[590, 591] did you guys decide to use log10() rather than log() for a reason? it doesn't really matter, but
scientists are almost always talking about natural logs when they just say "log". i think USGS digs log10,
which is chill. 

[619] will the user know what "ideal method" means? (see documentation suggestions above)
You use "ms_recommended" elsewhere. "Recommended" seems fine.

[removed on ~619 etc.] i've seen ungroup() used on a lot of dataframes that aren't grouped to begin with.
this function should only only be meaningful if it follows group(). have you found another way to use it?

[627-628] this warning is written as if from the perspective of the program. the following rephrase
would make it clearer to a human unfamiliar with the function internals:
"The composite method would be recommended by Aulenbach et al. 2016 for <var> at <site> (<year>),
but that method results in illegal values. Using period-weighting instead."
Please look over the other messages and make clarifications like this where possible.

[682, 684] def only run the methods that have been requested. the core methods on 504-525 should
all be run conditionally, depending on the value of `methods`, and the code that follows should
be flexible enough to handle any combination. 

[691-695] some of these TODOs are essential. 5th for sure. 1st too, because it will make you think about
organization and efficiency.

removed junk code at the bottom, after the function definition 

i get a wall of "length mismatch" warnings when i run
    ms_flux <- ms_calc_flux_rsfme(chemistry = chemistry, q = q, q_type = 'discharge',
                                  method = 'average', aggregation = 'monthly')
using the input data from test_ms_calc_flux_rsfme.R. That warning is usually problematic.
If it's not in this case, it should be suppressed as it will make every user run for the hills.

