### PR TITLE
v2.0.2 (bugfix)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: macrosheds
 Title: Tools for interfacing with the MacroSheds dataset
-Version: 2.0.1
-Date: 2024-10-01
+Version: 2.0.2
+Date: 2024-10-25
 Authors@R: c(
     person(given = "Spencer",
            family = "Rhea",

--- a/R/ms_load_spatial_product.R
+++ b/R/ms_load_spatial_product.R
@@ -130,14 +130,14 @@ ms_load_spatial_product <- function(macrosheds_root,
 
     shapes <- lapply(prodpaths,
                      function(x){
-                         sf::st_read(x,
-                                     stringsAsFactors = FALSE,
-                                     quiet = TRUE) %>%
+                         z <- sf::st_read(x,
+                                          stringsAsFactors = FALSE,
+                                          quiet = TRUE) %>%
                              slice_tail()
+                         sw(sf::st_set_crs(z, 4326))
                      })
 
     combined <- suppressMessages(Reduce(bind_rows, shapes))
 
     return(combined)
 }
-


### PR DESCRIPTION
adapted `load_spatial_product` to handle misspecified CRS values in stream gauge locations